### PR TITLE
Updated how instrument and sc kernels are separated

### DIFF
--- a/SpiceQL/db/lro.json
+++ b/SpiceQL/db/lro.json
@@ -3,22 +3,14 @@
       "ck" : {
           "reconstructed" : {
               "kernels": "moc42r?_[0-9]{7}_[0-9]{7}_v[0-9]{2}.bc"
-          },
-          "deps" : {
-            "objs" : ["/base/lsk", "/moc/sclk"]
           }
       },
       "spk" : {
         "reconstructed" : {
-          "kernels" : ["fdf29_[0-9]{7}_[0-9]{7}_[0-9]{3}.bsp", "fdf29r_[0-9]{7}_[0-9]{7}_[0-9]{3}.bsp"],
-          "deps" : {}
+          "kernels" : ["fdf29r?_[0-9]{7}_[0-9]{7}_[nbv][0-9]{2}.bsp"]
         },
         "smithed" : {
-          "kernels" : ["LRO_.*_GRGM660.*.bsp", "LRO_.*_GRGM900C.*.BSP"],
-          "deps" : {}
-        },
-        "deps" : {
-          "objs" : ["/base/lsk", "/moc/sclk"]
+          "kernels" : ["LRO_.*_GRGM660.*.bsp", "LRO_.*_GRGM900C.*.BSP"]
         }
       },
       "sclk" : {
@@ -27,43 +19,19 @@
       "fk" : {
         "kernels" : ["lro_frames_[0-9]{7}_v[0-9]{2}.tf"]
       },
-      "ik" : {
-        "kernels" : ["lro_instruments_v[0-9]{2}.ti"]
+      "pck" : {
+        "kernels" : ["moon_080317.tf", "moon_assoc_me.tf"]
       }
   },
 
   "lroc" : {
     "ck" : {
       "reconstructed" : {
-        "kernels" : ["lrolc_[0-9]{7}_[0-9]{7}_v[0-9]{2}.bc", "soc31_[0-9]{7}_[0-9]{7}_v[0-9]{2}.bc"],
-        "deps" : {}
-      },
-      "deps" : {
-        "objs" : ["/base/lsk", "/moc/sclk", "/moc/ck"]
-      }
-    },
-    "spk" : {
-      "reconstructed" : {
-        "kernels" : "fdf29r?_[0-9]{7}_[0-9]{7}_[nbv][0-9]{2}.bsp",
-        "deps" : {}
-      },
-      "smithed" : {
-        "kernels" : [
-          "LRO_CO_[0-9]{6}_GRGM660PRIMAT270.bsp",
-          "LRO_[A-Z]{2}_[0-9]{2}_[0-9]{6}_GRGM660PRIMAT270.bsp",
-          "LRO_CO_[0-9]{6}_GRGM900C_L600.BSP",
-          "LRO_[A-Z]{2}_[0-9]{2}_[0-9]{6}_GRGM900C_L600.BSP"],
-        "deps" : {}
-      },
-      "deps" : {
-          "objs" : ["/base/lsk", "/moc/sclk"]
+        "kernels" : ["lrolc_[0-9]{7}_[0-9]{7}_v[0-9]{2}.bc", "soc31_[0-9]{7}_[0-9]{7}_v[0-9]{2}.bc"]
       }
     },
     "tspk" : {
       "kernels" : ["de421.bsp", "moon_pa_de421_1900-2050.bpc"]
-    },
-    "fk" : {
-      "kernels" : "lro_frames_[0-9]{7}_v[0-9]{2}.tf"
     },
     "ik" : {
       "kernels" :"lro_lroc_v[0-9]{2}.ti"
@@ -71,9 +39,6 @@
     "iak" : {
       "kernels" : "lro_instrumentAddendum_v[0-9]{2}.ti"
     },
-    "pck" : {
-      "kernels" : ["moon_080317.tf", "moon_assoc_me.tf"],
-      "deps" : "/base/pck"
-    }
+    "deps" : "moc"
   }
 }

--- a/SpiceQL/include/utils.h
+++ b/SpiceQL/include/utils.h
@@ -258,6 +258,20 @@ namespace SpiceQL {
    nlohmann::json getMissionConfig(std::string mission);
 
 
+   /**
+    * @brief Returns the Instrument specific Spice config.
+    *
+    * Given an instrument, search a prioritized list of directories for
+    * the json config file that contains that instrument. See getAvailableConfigs
+    * for the search hierarchy
+    *
+    * @param instrument The name of the instrument to find a config for
+    *
+    * @returns The config file parsed into a JSON object
+   **/
+   nlohmann::json getInstrumentConfig(std::string instrument);
+
+
   /**
     * @brief Returns std::vector<string> interpretation of a json array.
     *

--- a/SpiceQL/include/utils.h
+++ b/SpiceQL/include/utils.h
@@ -53,6 +53,19 @@ namespace SpiceQL {
 
 
   /**
+   * @brief Merge two json configs
+   *
+   * When arrays are merged, the values from the base config will appear
+   * first in the merged config.
+   *
+   * @param baseConfig First json config
+   * @param mergingConfig Second json config
+   * @return nlohmann::json
+   */
+  nlohmann::json mergeConfigs(nlohmann::json baseConfig, nlohmann::json mergingConfig);
+
+
+  /**
     * @brief ls, like in unix, kinda. Also it's a function.
     *
     * Iterates the input path and returning a list of files. Optionally, recursively.

--- a/SpiceQL/src/query.cpp
+++ b/SpiceQL/src/query.cpp
@@ -203,36 +203,6 @@ namespace SpiceQL {
 
 
   json searchMissionKernels(json kernels, std::vector<double> times, bool isContiguous)  {
-    auto loadTimeKernels = [&](json j) -> vector<shared_ptr<Kernel>> {
-      vector<json::json_pointer> p = findKeyInJson(j, "sclk", true);
-      vector<string> sclks;
-
-      if (!p.empty()) {
-        sclks = jsonArrayToVector(j[p.at(0)]);
-        sort(sclks.begin(), sclks.end(), greater<string>());
-      }
-
-
-      json baseConf = getMissionConfig("base");
-      string dataDir = getDataDirectory();
-      baseConf = searchMissionKernels(dataDir, baseConf);
-      p = findKeyInJson(baseConf, "lsk", true);
-
-      vector<string> lsks = jsonArrayToVector(baseConf.at(p.at(0))["kernels"]);
-      sort(lsks.begin(), lsks.end(), greater<string>());
-
-      vector<shared_ptr<Kernel>> timeKernels(2);
-
-      if(lsks.size()) {
-        timeKernels.emplace_back(new Kernel(lsks.at(0)));
-      }
-      if (sclks.size()) {
-        timeKernels.emplace_back(new Kernel(sclks.at(0)));
-      }
-      return timeKernels;
-    };
-
-
     json reducedKernels;
 
     vector<json::json_pointer> ckpointers = findKeyInJson(kernels, "ck", true);

--- a/SpiceQL/src/utils.cpp
+++ b/SpiceQL/src/utils.cpp
@@ -526,6 +526,22 @@ namespace SpiceQL {
   }
 
 
+  json getInstrumentConfig(string instrument) {
+    vector<string> paths = getAvailableConfigFiles();
+    json conf;
+
+    for(const fs::path &p : paths) {
+      ifstream i(p);
+      i >> conf;
+      if (conf.contains(instrument)) {
+        return conf[instrument];
+      }
+    }
+
+    throw invalid_argument(fmt::format("Config file for \"{}\" not found", instrument));
+  }
+
+
   string getKernelType(string kernelPath) {
     SpiceChar type[6];
     SpiceChar source[6];

--- a/SpiceQL/tests/QueryTests.cpp
+++ b/SpiceQL/tests/QueryTests.cpp
@@ -250,27 +250,22 @@ TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernelsApollo17) {
   ASSERT_EQ(res["APOLLO_PAN"]["iak"]["kernels"].size(), 2);
 }
 
-TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernelsLRO) {
-  fs::path dbPath = getMissionConfigFile("lro");
-
-  ifstream i(dbPath);
-  nlohmann::json conf;
-  i >> conf;
+TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernelsLROC) {
+  nlohmann::json conf = getInstrumentConfig("lroc");
 
   MockRepository mocks;
   mocks.OnCallFunc(ls).Return(paths);
 
   nlohmann::json res = searchMissionKernels("/isis_data/", conf);
 
-  EXPECT_EQ(res["lroc"]["ck"]["reconstructed"]["kernels"].size(), 8);
-  EXPECT_EQ(res["lroc"]["ck"]["deps"]["objs"].size(), 3);
-  EXPECT_EQ(res["lroc"]["spk"]["reconstructed"]["kernels"].size(), 8);
-  EXPECT_EQ(res["lroc"]["spk"]["smithed"]["kernels"].size(), 14);
-  EXPECT_EQ(res["lroc"]["iak"]["kernels"].size(), 2);
-  EXPECT_EQ(res["lroc"]["ik"]["kernels"].size(), 2);
-  EXPECT_EQ(res["lroc"]["pck"]["kernels"].size(), 2);
-  EXPECT_EQ(res["lroc"]["fk"]["kernels"].size(), 2);
-  EXPECT_EQ(res["lroc"]["tspk"]["kernels"].size(), 2);
+  EXPECT_EQ(res["ck"]["reconstructed"]["kernels"].size(), 16);
+  EXPECT_EQ(res["spk"]["reconstructed"]["kernels"].size(), 8);
+  EXPECT_EQ(res["spk"]["smithed"]["kernels"].size(), 14);
+  EXPECT_EQ(res["iak"]["kernels"].size(), 2);
+  EXPECT_EQ(res["ik"]["kernels"].size(), 2);
+  EXPECT_EQ(res["pck"]["kernels"].size(), 2);
+  EXPECT_EQ(res["fk"]["kernels"].size(), 2);
+  EXPECT_EQ(res["tspk"]["kernels"].size(), 2);
 }
 
 

--- a/SpiceQL/tests/UtilTests.cpp
+++ b/SpiceQL/tests/UtilTests.cpp
@@ -49,3 +49,10 @@ TEST(UtilTests, findKeyInJson) {
   EXPECT_EQ(res.at(1).to_string(), "/l1a/me");
   EXPECT_EQ(res.at(2).to_string(), "/me");
 }
+
+TEST(UtilTests, getInstrumentConfig) {
+  nlohmann::json lrocConfig = getInstrumentConfig("lroc");
+  nlohmann::json lroConfig = getMissionConfig("lro");
+
+  EXPECT_EQ(lrocConfig, lroConfig["lroc"]);
+}


### PR DESCRIPTION
This PR adds a new way to get the config for a specific instrument instead of having to pull the entire mission config. `getInstrumentConfig` searches all of the config files for a named object and then merges any objects in the same file specified under the `deps` key. See the lro config for what this looks like.

There's other ways we could specify the dependencies like nesting the configs somehow so it would be:
```
{
  spacecraft: {
    ck: ....
    instrument_1: {
      ck: ...
    },
    instrument_2 :{
      ck: ...
    }
  }
}
```

and when you call `getInstrumentConfig("instrument_1")` it will merge all of the kernels from the spacecraft object into the kernels specified in the instrument_1 object. I decided not to go this way because it would require knowing which keys in the spacecraft object are kernels and which are instruments. This seemed like it would restrict our config format in an unusual place. Maybe once #109 is merged we can specify the format there? I'm also not sure how this will work with #108. Either way, the basic parsing and merging changes are still re-usable and there won't need to be a big change to the bulk of this PR.

Fixes #98 