### PR TITLE
Improved deps processing and added to Config

### DIFF
--- a/SpiceQL/db/apollo16.json
+++ b/SpiceQL/db/apollo16.json
@@ -39,16 +39,19 @@
       },
       "iak": {
         "kernels": "apollo16MetricAddendum[0-9]{3}.ti"
-      }
+      },
+      "deps" : ["/apollo16"]
     },
     "panoramic": {
       "ik": {
         "kernels": "apollo16_panoramic.[0-9]{4}.ti"
-      }
+      },
+      "deps" : ["/apollo16"]
     },
     "apollo_pan": {
       "iak": {
         "kernels": "apolloPanAddendum[0-9]{3}.ti"
-      }
+      },
+      "deps" : ["/apollo16"]
     }
   }

--- a/SpiceQL/db/apollo17.json
+++ b/SpiceQL/db/apollo17.json
@@ -32,7 +32,8 @@
     "metric": {
       "iak": {
         "kernels": "apollo17MetricAddendum[0-9]{3}.ti"
-      }
+      },
+      "deps" : ["/apollo17"]
     },
     "panoramic": {
       "ik": {
@@ -41,11 +42,13 @@
           "apollo17_metric_v2.[0-9]{4}.ti",
           "apollo17_panoramic.[0-9]{4}.ti"
         ]
-      }
+      },
+      "deps" : ["/apollo17"]
     },
     "apollo_pan": {
       "iak": {
         "kernels": "apolloPanAddendum[0-9]{3}.ti"
-      }
+      },
+      "deps" : ["/apollo17"]
     }
 }

--- a/SpiceQL/db/base.json
+++ b/SpiceQL/db/base.json
@@ -1,8 +1,7 @@
 {
   "base" : {
     "lsk" : {
-      "kernels" : ["naif[0-9]{4}.tls"],
-      "deps" : []
+      "kernels" : ["naif[0-9]{4}.tls"]
     }
   }
 }

--- a/SpiceQL/db/cassini.json
+++ b/SpiceQL/db/cassini.json
@@ -13,12 +13,6 @@
           "99213_99243cb_ISS.bc",
           "0[0-9]{4}_[0-9]{5}c[0-9]{1}_ISS.bc"
         ]
-      },
-      "deps": {
-        "objs": [
-          "/base/lsk",
-          "/mess/lsk"
-        ]
       }
     },
     "fk": {
@@ -38,10 +32,6 @@
       "kernels": "pck[0-9]{5}.tpc",
       "smithed": {
         "kernels": "cpck15Dec2017_2019Shape.tpc"
-      },
-      "deps": {
-        "lsk": "naif0012.tls",
-        "objs":[]
       }
     },
     "sclk": {

--- a/SpiceQL/db/clem1.json
+++ b/SpiceQL/db/clem1.json
@@ -9,18 +9,11 @@
       },
       "smithed" : {
         "kernels" : "clem_ulcn2005_6hr.bc"
-      },
-      "deps" : {
-        "objs" : ["/base/lsk", "/clem1/sclk"]
       }
     },
     "spk" : {
       "reconstructed" : {
-        "kernels" :  "clem.*\\.bsp",
-        "deps": {}
-      },
-      "deps" : {
-        "objs" : ["/base/lsk", "/clem1/sclk"]
+        "kernels" :  "clem.*\\.bsp"
       }
     },
     "fk" : {

--- a/SpiceQL/db/clem1.json
+++ b/SpiceQL/db/clem1.json
@@ -26,11 +26,13 @@
     },
     "iak" : {
       "kernels" : "uvvisAddendum[0-9]{3}.ti"
-    }
+    },
+    "deps" : ["/clem1"]
   },
   "nir" : {
     "iak" : {
       "kernels" : "nirAddendum[0-9]{3}.ti"
-    }
+    },
+    "deps" : ["/clem1"]
   }
 }

--- a/SpiceQL/db/galileo.json
+++ b/SpiceQL/db/galileo.json
@@ -5,26 +5,15 @@
     },
     "ck" : {
       "reconstructed" : {
-        "kernels" : ["ck[0-9]{5}.*\\.bc", "CKmerge_type3.plt.bck"],
-        "deps" : {}
+        "kernels" : ["ck[0-9]{5}.*\\.bc", "CKmerge_type3.plt.bck"]
       },
       "smithed" : {
-        "kernels" : ["galssi_.*med.bck","galssi_io.*[0-9]{6}.*\\.bck","galssi_eur_.*\\.bc"],
-        "deps" : {
-          "objs" : ["/galileo/pck/smithed"]
-        }
-      },
-      "deps" : {
-          "objs" : ["/base/lsk", "/galileo/sclk"]
+        "kernels" : ["galssi_.*med.bck","galssi_io.*[0-9]{6}.*\\.bck","galssi_eur_.*\\.bc"]
       }
     },
     "spk" : {
         "reconstructed" : {
-          "kernels" : "s[0-9]{6}.*\\.bsp",
-          "deps" : {}
-        },
-        "deps" : {
-            "objs" : ["/base/lsk", "/galileo/sclk"]
+          "kernels" : "s[0-9]{6}.*\\.bsp"
         }
     },
     "iak" : {
@@ -32,12 +21,10 @@
     },
     "pck" : {
       "smithed" : {
-        "kernels" : "pck00010_msgr_v[0-9]{2}.tpc",
-        "deps" : []
+        "kernels" : "pck00010_msgr_v[0-9]{2}.tpc"
       },
       "na" : {
-        "kernels" : "pck0000[0-9].tpc",
-        "deps" : []
+        "kernels" : "pck0000[0-9].tpc"
       }
     }
   }

--- a/SpiceQL/db/juno.json
+++ b/SpiceQL/db/juno.json
@@ -2,23 +2,15 @@
     "juno" : {
         "ck" : {
             "reconstructed" : {
-              "kernels" : "juno_sc_rec(_[0-9]{6}){2}_v0[0-9].bc",
-              "deps" : {}
+              "kernels" : "juno_sc_rec(_[0-9]{6}){2}_v0[0-9].bc"
             },
             "predicted" : {
               "kernels": "juno_sc_raw(_[0-9]{6}){2}.bc"
-            },
-            "deps" : {
-                "objs" : ["/base/lsk", "/juno/sclk"]
             }
         },
         "spk" : {
             "reconstructed" : {
-              "kernels" : "juno_rec(_[0-9]{6}){3}.bsp",
-              "deps" : {}
-            },
-            "deps" : {
-                "objs" : ["/base/lsk"]
+              "kernels" : "juno_rec(_[0-9]{6}){3}.bsp"
             }
         },
         "fk" : {

--- a/SpiceQL/db/lro.json
+++ b/SpiceQL/db/lro.json
@@ -44,6 +44,6 @@
     "ik" : {
       "kernels" :"lro_lroc_v[0-9]{2}.ti"
     },
-    "deps" : "moc"
+    "deps" : "/moc"
   }
 }

--- a/SpiceQL/db/lro.json
+++ b/SpiceQL/db/lro.json
@@ -30,7 +30,7 @@
       "pck" : {
         "kernels" : ["moon_080317.tf", "moon_assoc_me.tf"]
       },
-      "deps" : "lro"
+      "deps" : "/lro"
   },
   "lroc" : {
     "ck" : {

--- a/SpiceQL/db/mess.json
+++ b/SpiceQL/db/mess.json
@@ -2,24 +2,16 @@
     "mdis" : {
         "ck" : {
             "reconstructed" : {
-              "kernels" : "msgr_[0-9]{4}_v[0-9]{2}.bc",
-              "deps" : {}
+              "kernels" : "msgr_[0-9]{4}_v[0-9]{2}.bc"
             },
             "smithed" : {
-              "kernels" : "msgr_mdis_sc[0-9]{4}_usgs_v[0-9]{1}.bc",
-              "deps" : {}
+              "kernels" : "msgr_mdis_sc[0-9]{4}_usgs_v[0-9]{1}.bc"
             },
-            "deps" : {
-                "objs" : ["/mess/ck", "/mdis_att/ck", "/base/lsk", "/mess/sclk"]
-            }
+            "deps" : ["/mess/ck", "/mdis_att/ck"]
         },
         "spk" : {
             "reconstructed" : {
-              "kernels" : "msgr_20040803.*\\.bsp",
-              "deps" : {}
-            },
-            "deps" : {
-                "objs" : ["/base/lsk", "/mess/sclk"]
+              "kernels" : "msgr_20040803.*\\.bsp"
             }
         },
         "tspk" : {
@@ -36,30 +28,21 @@
         },
         "pck" : {
           "na" : {
-            "kernels" : "pck00010_msgr_v[0-9]{2}.tpc",
-            "deps" : []
+            "kernels" : "pck00010_msgr_v[0-9]{2}.tpc"
           }
         }
     },
     "mdis_att" : {
         "ck" : {
             "reconstructed" : {
-              "kernels" : "msgr_mdis_sc[0-9]{6}_[0-9]{6}_sub_v[0-9]{1}.bc",
-              "deps" : {}
-            },
-            "deps" : {
-                "objs" : ["/base/lsk", "/mess/sclk"]
+              "kernels" : "msgr_mdis_sc[0-9]{6}_[0-9]{6}_sub_v[0-9]{1}.bc"
             }
         }
     },
     "mess" : {
         "ck" : {
             "reconstructed" : {
-              "kernels" : "msgr_mdis_gm[0-9]{6}_[0-9]{6}v[0-9]{1}.bc",
-              "deps" : {}
-            },
-            "deps" : {
-                "objs" : ["/base/lsk", "/mess/sclk"]
+              "kernels" : "msgr_mdis_gm[0-9]{6}_[0-9]{6}v[0-9]{1}.bc"
             }
         },
         "sclk" : {

--- a/SpiceQL/db/mro.json
+++ b/SpiceQL/db/mro.json
@@ -29,7 +29,8 @@
         },
         "iak" : {
             "kernels" : ["marciAddendum[0-9]{3}.ti"]
-        }
+        },
+        "deps" : ["/mro"]
     },
     "hirise" : {
         "ik" : {
@@ -37,7 +38,8 @@
         },
         "iak" : {
             "kernels" : ["hiriseAddendum[0-9]{3}.ti"]
-        }
+        },
+        "deps" : ["/mro"]
     },
     "crism" : {
         "ik" : {
@@ -45,7 +47,8 @@
         },
         "iak" : {
             "kernels" : ["crismAddendum[0-9]{3}.ti"]
-        }
+        },
+        "deps" : ["/mro"]
     } ,
     "ctx" : {
         "ik" : {
@@ -53,6 +56,7 @@
         },
         "iak" : {
             "kernels" : ["mroctxAddendum[0-9]{3}.ti"]
-        }
+        },
+        "deps" : ["/mro"]
     }
   }

--- a/SpiceQL/db/mro.json
+++ b/SpiceQL/db/mro.json
@@ -6,9 +6,6 @@
             },
             "reconstructed" : {
                 "kernels": ["mro_cruise.bsp", "mro_ab.bsp", "mro_psp[0-9].bsp", "mro_psp[0-9]{2}.bsp", "mro_psp_rec.bsp", "mro_psp.*_ssd_mro95a.bsp", "mro_psp.*_ssd_mro110c.bsp"]
-            },
-            "deps" : {
-              "objs" : ["/base/lsk", "/mro/sclk"]
             }
         },
         "ck" : {
@@ -17,10 +14,7 @@
           },
           "reconstructed" : {
             "kernels" : ["mro_sc_cru_[0-9]{6}_[0-9]{6}.bc", "mro_sc_ab_[0-9]{6}_[0-9]{6}.bc", "mro_sc_psp_[0-9]{6}_[0-9]{6}.bc", "mro_sc_psp_[0-9]{6}_[0-9]{6}_v2.bc"]
-          }, 
-          "deps" : {
-            "objs" : ["/base/lsk", "/mro/sclk"]
-          } 
+          }
         },
         "sclk" : {
           "kernels" : ["MRO_SCLKSCET.[0-9]{5}.65536.tsc", "MRO_SCLKSCET.[0-9]{5}.tsc"]

--- a/SpiceQL/include/utils.h
+++ b/SpiceQL/include/utils.h
@@ -65,17 +65,17 @@ namespace SpiceQL {
    **/
   std::vector<std::string> getPathsFromRegex (std::string root, nlohmann::json r);
 
+
   /**
    * @brief Merge two json configs
    *
    * When arrays are merged, the values from the base config will appear
    * first in the merged config.
    *
-   * @param baseConfig First json config
-   * @param mergingConfig Second json config
-   * @return nlohmann::json
+   * @param baseConfig The config to merge into
+   * @param mergingConfig The config to merge into the base config
    */
-  nlohmann::json mergeConfigs(nlohmann::json baseConfig, nlohmann::json mergingConfig);
+  void mergeConfigs(nlohmann::json &baseConfig, const nlohmann::json &mergingConfig);
 
 
   /**
@@ -285,17 +285,29 @@ namespace SpiceQL {
 
 
    /**
-    * @brief Returns the Instrument specific Spice config.
+    * @brief resolve the dependencies in a config in place
     *
-    * Given an instrument, search a prioritized list of directories for
-    * the json config file that contains that instrument. See getAvailableConfigs
-    * for the search hierarchy
+    * Given a config with "deps" keys in it and a second config to extract
+    * dependencies from, recursively resolve all of the deps into their actual
+    * values. Only allows up to 10 recurssions.
     *
-    * @param instrument The name of the instrument to find a config for
+    * @param config The config to populate
+    * @param dependencies The config to pull dependencies from
     *
-    * @returns The config file parsed into a JSON object
-   **/
-   nlohmann::json getInstrumentConfig(std::string instrument);
+    * @returns The full instrument config
+    */
+   void resolveConfigDependencies(nlohmann::json &config, const nlohmann::json &dependencies);
+
+
+   /**
+    * @brief erase a part of a json object based on a json pointer
+    *
+    * @param j The json object ot erase part of. Modified in place
+    * @param ptr The object to erase
+    *
+    * @returns The number of objects removed
+    */
+   size_t eraseAtPointer(nlohmann::json &j, nlohmann::json::json_pointer ptr);
 
 
   /**

--- a/SpiceQL/src/config.cpp
+++ b/SpiceQL/src/config.cpp
@@ -48,6 +48,7 @@ namespace SpiceQL {
 
 
   json Config::evaluateJson(json eval_json, bool merge) {
+    resolveConfigDependencies(eval_json, config);
 
     vector<json::json_pointer> json_to_eval = SpiceQL::findKeyInJson(eval_json, "kernels", true);
 

--- a/SpiceQL/src/query.cpp
+++ b/SpiceQL/src/query.cpp
@@ -186,6 +186,12 @@ namespace SpiceQL {
   json searchMissionKernels(json kernels, std::vector<double> times, bool isContiguous)  {
     json reducedKernels;
 
+    // Load any SCLKs in the config
+    vector<KernelSet> sclkKernels;
+    for (auto &p : findKeyInJson(kernels, "sclk", true)) {
+      sclkKernels.push_back(KernelSet(kernels[p]));
+    }
+
     vector<json::json_pointer> ckpointers = findKeyInJson(kernels, "ck", true);
     vector<json::json_pointer> spkpointers = findKeyInJson(kernels, "spk", true);
     vector<json::json_pointer> pointers(ckpointers.size() + spkpointers.size());

--- a/SpiceQL/src/utils.cpp
+++ b/SpiceQL/src/utils.cpp
@@ -590,19 +590,6 @@ namespace SpiceQL {
     }
   }
 
-  // json resolveConfigDependencies(json config, string instrument) {
-  //   if (config[instrument].contains("deps")) {
-  //     for(auto & dep: jsonArrayToVector(config[instrument]["deps"])) {
-  //       json::json_pointer depPtr(dep);
-  //       json::json_pointer confPtr;
-  //       confPtr.push_back(instrument);
-  //       mergeConfigs(config[confPtr], config[depPtr]);
-  //     }
-  //     config[instrument].erase("deps");
-  //   }
-  //   return config[instrument];
-  // }
-
 
   size_t eraseAtPointer(json &j, json::json_pointer ptr) {
     vector<string> path;

--- a/SpiceQL/src/utils.cpp
+++ b/SpiceQL/src/utils.cpp
@@ -582,7 +582,8 @@ namespace SpiceQL {
       if (conf.contains(instrument)) {
         if (conf[instrument].contains("deps")) {
           for(auto & dep: jsonArrayToVector(conf[instrument]["deps"])) {
-            conf[instrument] = mergeConfigs(conf[instrument], conf[dep]);
+            json::json_pointer depPtr(dep);
+            conf[instrument] = mergeConfigs(conf[instrument], conf[depPtr]);
           }
           conf[instrument].erase("deps");
         }

--- a/SpiceQL/tests/Fixtures.cpp
+++ b/SpiceQL/tests/Fixtures.cpp
@@ -157,7 +157,7 @@ void LroKernelSet::SetUp() {
   lskPath = root / "clocks" / "naif0012.tls";
   sclkPath = root / "clocks" / "lro_clkcor_2020184_v00.tsc";
 
-  pool.loadClockKernels();
+  Kernel sclk(sclkPath);
 
   // Write CK1 ------------------------------------------
   fs::create_directory(root / "ck");

--- a/SpiceQL/tests/FunctionalTestsConfig.cpp
+++ b/SpiceQL/tests/FunctionalTestsConfig.cpp
@@ -43,12 +43,6 @@ TEST_F(TestConfig, FunctionalTestConfigEval) {
   ASSERT_EQ(pointer_eval_res[pointer].size(), expected_number);
   ASSERT_EQ(testConfig[pointer].size(), expected_number);
 
-  pointer = "/clem1/ck/deps/objs"_json_pointer;
-  expected_number = 2;
-  ASSERT_EQ(config_eval_res[pointer].size(), expected_number);
-  ASSERT_EQ(pointer_eval_res[pointer].size(), expected_number);
-  ASSERT_EQ(testConfig[pointer].size(), expected_number);
-
   pointer = "/clem1/spk/reconstructed/kernels"_json_pointer;
   expected_number = 2;
   ASSERT_EQ(config_eval_res[pointer].size(), expected_number);
@@ -100,10 +94,6 @@ TEST_F(TestConfig, FunctionalTestConfigGlobalEval) {
 
   pointer = "/clem1/ck/smithed/kernels"_json_pointer;
   expected_number = 1;
-  ASSERT_EQ(config_eval_res[pointer].size(), expected_number);
-
-  pointer = "/clem1/ck/deps/objs"_json_pointer;
-  expected_number = 2;
   ASSERT_EQ(config_eval_res[pointer].size(), expected_number);
 
   pointer = "/clem1/spk/reconstructed/kernels"_json_pointer;

--- a/SpiceQL/tests/KernelTests.cpp
+++ b/SpiceQL/tests/KernelTests.cpp
@@ -22,13 +22,13 @@ TEST_F(LroKernelSet, UnitTestStackedKernelConstructorDestructor) {
     ktotal_c("text", &nkernels);
 
     // base LSK still loaded
-    EXPECT_EQ(nkernels, 3);
+    EXPECT_EQ(nkernels, 2);
     EXPECT_EQ(pool.getRefCounts().at(lskPath), 1);
   }
 
   // SCLKs and LSKs are considered text kernels, so they should stay loaded
   ktotal_c("text", &nkernels);
-  EXPECT_EQ(nkernels, 2);
+  EXPECT_EQ(nkernels, 1);
   EXPECT_EQ(pool.getRefCount(lskPath), 0);
 }
 
@@ -46,13 +46,13 @@ TEST_F(LroKernelSet, UnitTestStackedKernelCopyConstructor) {
     ktotal_c("text", &nkernels);
 
     // 5 total text kernels, but the lsk should have been loaded 3 times
-    EXPECT_EQ(nkernels, 5);
+    EXPECT_EQ(nkernels, 4);
     EXPECT_EQ(pool.getRefCounts().at(lskPath), 3);
   }
 
   // SCLKs and LSKs are considered text kernels, so they should stay loaded
   ktotal_c("text", &nkernels);
-  EXPECT_EQ(nkernels, 2);
+  EXPECT_EQ(nkernels, 1);
   EXPECT_EQ(pool.getRefCount(lskPath), 0);
 }
 
@@ -79,7 +79,7 @@ TEST_F(LroKernelSet, UnitTestStackedKernelSetConstructorDestructor) {
 
     // should match what spice counts
     ktotal_c("text", &nkernels);
-    EXPECT_EQ(nkernels, 8);
+    EXPECT_EQ(nkernels, 7);
     ktotal_c("ck", &nkernels);
     EXPECT_EQ(nkernels, 2);
     ktotal_c("spk", &nkernels);
@@ -90,13 +90,13 @@ TEST_F(LroKernelSet, UnitTestStackedKernelSetConstructorDestructor) {
     EXPECT_EQ(pool.getRefCount(fkPath), 2);
     EXPECT_EQ(pool.getRefCount(ckPath1), 2);
     EXPECT_EQ(pool.getRefCount(spkPath1), 2);
-    EXPECT_EQ(pool.getRefCount(sclkPath), 3);
+    EXPECT_EQ(pool.getRefCount(sclkPath), 2);
     EXPECT_EQ(pool.getRefCount(ikPath2), 2);
   }
 
   // All kernels in previous stack should be unfurnished
   ktotal_c("text", &nkernels);
-  EXPECT_EQ(nkernels, 5);
+  EXPECT_EQ(nkernels, 4);
   ktotal_c("ck", &nkernels);
   EXPECT_EQ(nkernels, 1);
   ktotal_c("spk", &nkernels);
@@ -106,7 +106,7 @@ TEST_F(LroKernelSet, UnitTestStackedKernelSetConstructorDestructor) {
   EXPECT_EQ(pool.getRefCount(fkPath), 1);
   EXPECT_EQ(pool.getRefCount(ckPath1), 1);
   EXPECT_EQ(pool.getRefCount(spkPath1), 1);
-  EXPECT_EQ(pool.getRefCount(sclkPath), 2);
+  EXPECT_EQ(pool.getRefCount(sclkPath), 1);
   EXPECT_EQ(pool.getRefCount(ikPath2), 1);
 }
 

--- a/SpiceQL/tests/QueryTests.cpp
+++ b/SpiceQL/tests/QueryTests.cpp
@@ -107,7 +107,6 @@ TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernelsAllMess) {
 
   ASSERT_EQ(res["mdis"]["ck"]["reconstructed"]["kernels"].size(), 4);
   ASSERT_EQ(res["mdis"]["ck"]["smithed"]["kernels"].size(), 4);
-  ASSERT_EQ(res["mdis"]["ck"]["deps"]["objs"].size(), 4);
   ASSERT_EQ(res["mdis"]["spk"]["reconstructed"]["kernels"].size(), 2);
   ASSERT_EQ(res["mdis"]["tspk"]["kernels"].size(), 1);
   ASSERT_EQ(res["mdis"]["fk"]["kernels"].size(), 2);
@@ -116,11 +115,9 @@ TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernelsAllMess) {
   ASSERT_EQ(res["mdis"]["pck"]["na"]["kernels"].size(), 2);
 
   ASSERT_EQ(res["mdis_att"]["ck"]["reconstructed"]["kernels"].size(), 4);
-  ASSERT_EQ(res["mdis_att"]["ck"]["deps"]["objs"].size(), 2);
 
   ASSERT_EQ(res["mess"]["ck"]["reconstructed"]["kernels"].size(), 5);
   ASSERT_EQ(res["mess"]["sclk"]["kernels"].size(), 2);
-  ASSERT_EQ(res["mess"]["ck"]["deps"]["objs"].size(), 2);
 }
 
 
@@ -138,7 +135,6 @@ TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernelsClem1) {
 
   ASSERT_EQ(res["clem1"]["ck"]["reconstructed"]["kernels"].size(), 4);
   ASSERT_EQ(res["clem1"]["ck"]["smithed"]["kernels"].size(), 1);
-  ASSERT_EQ(res["clem1"]["ck"]["deps"]["objs"].size(), 2);
   ASSERT_EQ(res["clem1"]["spk"]["reconstructed"]["kernels"].size(), 2);
   ASSERT_EQ(res["clem1"]["fk"]["kernels"].size(), 1);
   ASSERT_EQ(res["clem1"]["sclk"]["kernels"].size(), 2);
@@ -163,16 +159,11 @@ TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernelsGalileo) {
   nlohmann::json res = searchMissionKernels("/isis_data/", conf);
 
   ASSERT_EQ(res["galileo"]["ck"]["reconstructed"]["kernels"].size(), 4);
-  ASSERT_EQ(res["galileo"]["ck"]["reconstructed"]["deps"].size(), 0);
   ASSERT_EQ(res["galileo"]["ck"]["smithed"]["kernels"].size(), 3);
-  ASSERT_EQ(res["galileo"]["ck"]["smithed"]["deps"]["objs"].size(), 1);
-  ASSERT_EQ(res["galileo"]["ck"]["deps"]["objs"].size(), 2);
   ASSERT_EQ(res["galileo"]["spk"]["reconstructed"]["kernels"].size(), 2);
   ASSERT_EQ(res["galileo"]["iak"]["kernels"].size(), 1);
   ASSERT_EQ(res["galileo"]["pck"]["smithed"]["kernels"].size(), 2);
-  ASSERT_EQ(res["galileo"]["pck"]["smithed"]["deps"].size(), 0);
   ASSERT_EQ(res["galileo"]["pck"]["na"]["kernels"].size(), 1);
-  ASSERT_EQ(res["galileo"]["pck"]["na"]["deps"].size(), 0);
   ASSERT_EQ(res["galileo"]["sclk"]["kernels"].size(), 1);
 }
 
@@ -192,7 +183,6 @@ TEST_F(KernelDataDirectories, FunctionalTestSearchMissionKernelsCassini) {
   ASSERT_EQ(res["cassini"]["ck"]["smithed"]["kernels"].size(), 3);
   ASSERT_EQ(res["cassini"]["fk"]["kernels"].size(), 2);
   ASSERT_EQ(res["cassini"]["iak"]["kernels"].size(), 3);
-  ASSERT_EQ(res["cassini"]["pck"]["deps"].size(), 1);
   ASSERT_EQ(res["cassini"]["pck"]["kernels"].size(), 3);
   ASSERT_EQ(res["cassini"]["pck"]["smithed"]["kernels"].size(), 1);
   ASSERT_EQ(res["cassini"]["sclk"]["kernels"].size(), 1);


### PR DESCRIPTION
Updated the deps processing to take json_pointers. I also changed it so you can specify deps at any level. So you can do something like:

```
{
  "instrument" : {
    "pck" : {
      "deps" : ["/base/pck"]
    },
    "deps" : ["/mission"]
  },
  "mission" : {
    ...
  }
}
```

I also inserted the resolution logic into the `Config::evaluateJson` so that it will be applied whenever you try to get an actual set of kernels out.

All of the tests need to be updated so that they go through the Config class instead of calling `getMissionConfig` but I don't know if that belongs in this PR or not.