### PR TITLE
Fixed optional include

### DIFF
--- a/SpiceQL/include/config.h
+++ b/SpiceQL/include/config.h
@@ -2,7 +2,6 @@
 
 #include <iostream>
 #include <regex>
-#include <optional>
 
 #include <nlohmann/json.hpp>
 

--- a/SpiceQL/include/io.h
+++ b/SpiceQL/include/io.h
@@ -6,6 +6,7 @@
  *
  **/
 
+#include <optional>
 #include <string>
 #include <vector>
 

--- a/SpiceQL/src/io.cpp
+++ b/SpiceQL/src/io.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <fstream>
-#include <optional>
 
 #include "SpiceUsr.h"
 

--- a/SpiceQL/src/utils.cpp
+++ b/SpiceQL/src/utils.cpp
@@ -6,7 +6,6 @@
 
 #include <exception>
 #include <fstream>
-#include <optional>
 
 #include <SpiceUsr.h>
 #include <SpiceZfc.h>


### PR DESCRIPTION
This was causing a build error on the deploy where optional wasn't defined when it compiled the io wrapper.